### PR TITLE
udev: Fix udev rule for ubuntu 20.04 by removing NAME=%k

### DIFF
--- a/udev/51-bms.rules
+++ b/udev/51-bms.rules
@@ -1,2 +1,2 @@
 KERNEL=="ttyUSB[0-9]*", OWNER="robot", GROUP="dialout", MODE="0666"
-KERNEL=="ttyUSB[0-9]*", ATTRS{idProduct}=="7523", ATTRS{idVendor}=="1a86", NAME="%k", SYMLINK="ttyUSB_BMS", GROUP="dialout", MODE="0666"
+KERNEL=="ttyUSB[0-9]*", ATTRS{idProduct}=="7523", ATTRS{idVendor}=="1a86", SYMLINK="ttyUSB_BMS", GROUP="dialout", MODE="0666"


### PR DESCRIPTION
The argument NAME="%k" doest not work in Ubuntu 20.04 and the symlink does not create.