### PR TITLE
Add Noetic compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -207,7 +207,7 @@ include_directories(
 
 catkin_install_python(PROGRAMS
   src/daly_bms/__init__.py
-  src/daly_bms/daly_bms.py
+  src/daly_bms/daly_bms_ros.py
   src/daly_bms/daly_bms_node.py
   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
 

--- a/src/daly_bms/__init__.py
+++ b/src/daly_bms/__init__.py
@@ -1,4 +1,4 @@
-from .daly_bms import DalyBMS
+from daly_bms.daly_bms_ros import DalyBMS
 try:
     from .daly_bms_bluetooth import DalyBMSBluetooth
 except ImportError:

--- a/src/daly_bms/daly_bms_node.py
+++ b/src/daly_bms/daly_bms_node.py
@@ -1,8 +1,10 @@
 #!/usr/bin/env python3
 
 import rospy
-from daly_bms import DalyBMS
-
+try:
+    from daly_bms_ros import DalyBMS
+except ImportError:
+    from daly_bms.daly_bms_ros import DalyBMS
 
 def main():
 

--- a/src/daly_bms/daly_bms_ros.py
+++ b/src/daly_bms/daly_bms_ros.py
@@ -1,7 +1,12 @@
 import threading
 import rospy
 
-from rcomponent.rcomponent import RComponent
+
+try:
+    from rcomponent import RComponent
+except ImportError:
+    from rcomponent.rcomponent import RComponent
+
 from robotnik_msgs.msg import BatteryStatus
 
 from dalybms import DalyBMS as DalyBMSDriver

--- a/udev/51-bms.rules
+++ b/udev/51-bms.rules
@@ -1,2 +1,2 @@
 KERNEL=="ttyUSB[0-9]*", OWNER="robot", GROUP="dialout", MODE="0666"
-KERNEL=="ttyUSB[0-9]*", ATTRS{idProduct}=="7523", ATTRS{idVendor}=="1a86", NAME="%k", SYMLINK="ttyUSB_BMS", GROUP="dialout", MODE="0666"
+KERNEL=="ttyUSB[0-9]*", ATTRS{idProduct}=="7523", ATTRS{idVendor}=="1a86", SYMLINK="ttyUSB_BMS", GROUP="dialout", MODE="0666"


### PR DESCRIPTION
These commits updates noetic-devel to the latest changes of devel branch.

This branch applies the following changes:
   - Rename the daly_bms.py to daly_bms_ros.py In Noetic the python name and package name cannot match.
   - Remove unused attributes from udev rule. In Noetic, the NAME=%k attribute disables the symlink. 

I tested this changes in a robot with Noetic and Melodic, but I would like someone else to test it in Melodic.
  

