### PR TITLE
Fix/ros2 jazzy messages

### DIFF
--- a/.github/Jenkinsfile
+++ b/.github/Jenkinsfile
@@ -1,3 +1,3 @@
 buildPackage(
-  upstreamProjects: 'robotnik_msgs'
+  upstreamProjects: 'robotnik_interfaces'
 )

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Prioritized local mirror for container image retrieval
 - Migrated from CMake to pure Python package
 - Expanded and refined README and CHANGELOG
+- Use robotnik_interfaces instead of robotnik_msgs
 
 ### Fixed
 - Refactored code to adhere to PEP standards

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Daly Battery Driver
 
-ROS package that uses [python-daly-bms driver](https://github.com/dreadnought/python-daly-bms) data to read information from Daly BMS devices and publishes it using robotnik_msgs/BatteryStatus message type.
+ROS package that uses [python-daly-bms driver](https://github.com/dreadnought/python-daly-bms) data to read information from Daly BMS devices and publishes it using robotnik_battery_msgs/BatteryStatus message type.
 
 ## Installation
 

--- a/common.repos.yaml
+++ b/common.repos.yaml
@@ -2,5 +2,5 @@
 repositories:
   robotnik_msgs:
     type: git
-    url: https://github.com/RobotnikAutomation/robotnik_msgs.git
+    url: https://github.com/RobotnikAutomation/robotnik_interfaces.git
     version: ros2-devel

--- a/daly_bms/daly_bms/daly_bms.py
+++ b/daly_bms/daly_bms/daly_bms.py
@@ -48,7 +48,7 @@ Constants:
 
 Dependencies:
     - rclpy
-    - robotnik_msgs
+    - robotnik_battery_msgs
     - dalybms
     - serial
 """
@@ -60,7 +60,7 @@ import time
 import serial
 
 from rclpy.node import Node
-from robotnik_msgs.msg import BatteryStatus
+from robotnik_battery_msgs.msg import BatteryStatus
 from dalybms import DalyBMS as DalyBMSDriver
 
 

--- a/daly_bms/package.xml
+++ b/daly_bms/package.xml
@@ -17,9 +17,9 @@
   <author email="aarnal@robotnik.es">Alex Arnal</author>
 
   <build_depend>rclpy</build_depend>
-  <build_depend>robotnik_msgs</build_depend>
+  <build_depend>robotnik_battery_msgs</build_depend>
   <exec_depend>rclpy</exec_depend>
-  <exec_depend>robotnik_msgs</exec_depend>
+  <exec_depend>robotnik_battery_msgs</exec_depend>
   <exec_depend>python3-serial</exec_depend>
   <exec_depend>python3-pip</exec_depend>
 

--- a/setup-container/values.yaml
+++ b/setup-container/values.yaml
@@ -80,7 +80,7 @@ builder:
       type: ros
       install: local
       packages:
-        - robotnik-msgs
+        - robotnik-battery-msgs
         - daly-bms
     - name: python
       type: pip

--- a/setup-container/values.yaml
+++ b/setup-container/values.yaml
@@ -65,10 +65,10 @@ builder:
             base: ros
             type: share
   vcs:
-    - path: "robotnik_msgs"
+    - path: "robotnik_interfaces"
       type: git
-      version: "ros2"
-      url: https://github.com/RobotnikAutomation/robotnik_msgs.git
+      version: "ros2-devel"
+      url: https://github.com/RobotnikAutomation/robotnik_interfaces.git
   requirements:
     - name: run
       type: general


### PR DESCRIPTION
This pull request includes multiple changes to switch from using `robotnik_msgs` to `robotnik_interfaces` and `robotnik_battery_msgs` across various files in the project. The most important changes are summarized below:

### Migration to new message types:

* [`.github/Jenkinsfile`](diffhunk://#diff-8490cb8fad8c1d766039ed1ac73ccbda22801a45cf6db5ce0800f92e2348554eL2-R2): Updated the `upstreamProjects` parameter to use `robotnik_interfaces` instead of `robotnik_msgs`.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L3-R3): Changed the message type from `robotnik_msgs/BatteryStatus` to `robotnik_battery_msgs/BatteryStatus`.
* [`daly_bms/daly_bms/daly_bms.py`](diffhunk://#diff-b1821930860fad1d8fb319b575a987c38e2069091245528e4905fb25cdc7f056L51-R51): Updated dependencies and imports to use `robotnik_battery_msgs` instead of `robotnik_msgs`. [[1]](diffhunk://#diff-b1821930860fad1d8fb319b575a987c38e2069091245528e4905fb25cdc7f056L51-R51) [[2]](diffhunk://#diff-b1821930860fad1d8fb319b575a987c38e2069091245528e4905fb25cdc7f056L63-R63)
* [`daly_bms/package.xml`](diffhunk://#diff-dccd3cbb0f4ce1a6e053e26381e614a50b99e09efe6377810bf49ee2d354edcbL20-R22): Modified build and execution dependencies to `robotnik_battery_msgs`.

### Repository updates:

* [`common.repos.yaml`](diffhunk://#diff-3fe4bdb85404d2709f9889d7c35cab42d64316b75c6236e6dfa1dae2c9ee834eL5-R5): Updated the URL and repository name from `robotnik_msgs` to `robotnik_interfaces`.
* [`setup-container/values.yaml`](diffhunk://#diff-94cfbb895aa88744b3b16f5668507166ff51fcd71e984499ae36e245c38a8417L68-R71): Changed the VCS path and URL to use `robotnik_interfaces` instead of `robotnik_msgs`.

### Documentation updates:

* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR41): Added an entry to reflect the change from `robotnik_msgs` to `robotnik_interfaces`.